### PR TITLE
Make the components named exports

### DIFF
--- a/src/components/create-feathers-auth-provider.ts
+++ b/src/components/create-feathers-auth-provider.ts
@@ -11,7 +11,7 @@ export default (
     AUTH_GET_PERMISSIONS = 'AUTH_GET_PERMISSIONS',
     AUTH_ERROR = 'AUTH_ERROR',
     AUTH_CHECK = 'AUTH_CHECK',
-  },
+  } = {},
 ) => async (type: any, params: any) => {
   switch (type) {
     case AUTH_LOGIN:

--- a/src/components/create-feathers-client.ts
+++ b/src/components/create-feathers-client.ts
@@ -4,19 +4,29 @@ import { ClientTypes, IFeathersClient } from '../types/feathers-client';
 
 export default (
   apiUrl: string,
-  authOptions = {
-    header: 'Authorization',
-    jwtStrategy: 'jwt',
-    locationErrorKey: 'error',
-    locationKey: 'access_token',
-    path: '/authentication',
-    scheme: 'Bearer',
-    storage: localStorage,
-    storageKey: 'feathers-jwt',
-  },
+  {
+    header = 'Authorization',
+    jwtStrategy = 'jwt',
+    locationErrorKey = 'error',
+    locationKey = 'access_token',
+    path = '/authentication',
+    scheme = 'Bearer',
+    storage = localStorage,
+    storageKey = 'feathers-jwt',
+  } = {},
   clientType: ClientTypes = ClientTypes.Rest,
   socketIOOptions: { timeout?: number } = {},
 ) => {
+  const authOptions = {
+    header,
+    jwtStrategy,
+    locationErrorKey,
+    locationKey,
+    path,
+    scheme,
+    storage,
+    storageKey,
+  };
   // @ts-ignore
   const app: IFeathersClient = feathers();
 

--- a/src/components/feathers-data-provider/index.ts
+++ b/src/components/feathers-data-provider/index.ts
@@ -61,7 +61,7 @@ export default (
     GET_ONE = 'GET_ONE',
     UPDATE = 'UPDATE',
     UPDATE_MANY = 'UPDATE_MANY',
-  }: IFeathersDataProviderConfig,
+  }: IFeathersDataProviderConfig = {},
 ) => {
   /**
    * @param {String} type One of the constants appearing at the top if this file, e.g. 'UPDATE'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import createFeathersAuthProvider from './components/create-feathers-auth-provid
 import createFeathersClient from './components/create-feathers-client';
 import createFeathersDataProvider from './components/feathers-data-provider';
 
-export default {
+export = {
   createFeathersAuthProvider,
   createFeathersClient,
   createFeathersDataProvider,


### PR DESCRIPTION
### What has changed

- I have changed `create-feathers-client`'s authOption parameter to a destructured version
- I have also changed the exports from the package to be named exports